### PR TITLE
automatic release with tags

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -1,0 +1,22 @@
+name: Automatic Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      packages: write
+      issues: write
+      pull-requests: write
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: false


### PR DESCRIPTION
This workflow automatically creates a release after creating a tag in the console and pushing it to the origin. It automatically collects all previous commits and ads them to the release.

when you want to create release:
1. git tag vX.X.X
2. git push origin vX.X.X